### PR TITLE
fix: forgotten negation in all-different test

### DIFF
--- a/src/tests/propagators/all_different.rs
+++ b/src/tests/propagators/all_different.rs
@@ -22,7 +22,7 @@ fn test_bounds_propagation() {
 
     solver.assert_bounds(x6, 4, 6);
     for value in 0..=3 {
-        assert!(solver.contains(x5, value));
+        assert!(!solver.contains(x5, value));
     }
 }
 


### PR DESCRIPTION
In the `test_bounds_propagation` test in `all_different.rs` it is checked that when variables `x1, x2, x3` are assigned values `[0,3]` and a fourth variable `x4` is assigned `[1, 2]` that a fifth variable `x5` should contain be assigned `[0, 3]`, however this should instead be being assigned a value not within `[0, 3]` as also [pointed out by another student](https://answers.ewi.tudelft.nl/posts/24133).

This pull request correctly negates the boolean.