### PR TITLE
Fix: doc-gen failing due to incorrect import

### DIFF
--- a/src/engine/cp/propagation/propagator.rs
+++ b/src/engine/cp/propagation/propagator.rs
@@ -1,8 +1,8 @@
 use super::PropagatorInitialisationContext;
 #[cfg(doc)]
-use crate::asserts::munchkin_assert_ADVANCED;
+use crate::asserts::ASSERT_ADVANCED;
 #[cfg(doc)]
-use crate::asserts::munchkin_assert_EXTREME;
+use crate::asserts::ASSERT_EXTREME;
 #[cfg(doc)]
 use crate::basic_types::Inconsistency;
 use crate::basic_types::PropagationStatusCP;


### PR DESCRIPTION
Fixes the doc-gen failing from unresolved import in `propagtor.rs`.

The main branch suffers from the same issue as the `meeting-munchkin` branch was suffering from, where an incorrect import causes the doc-gen to fail (as fixed in the branch with 2fd49373e143ab06dc45883ecb7be9f1c9b84b7d).