### PR TITLE
reset solver state after backtrack

### DIFF
--- a/src/engine/constraint_satisfaction_solver.rs
+++ b/src/engine/constraint_satisfaction_solver.rs
@@ -1666,7 +1666,6 @@ impl CSPSolverState {
     }
 
     pub(crate) fn declare_solving(&mut self) {
-        munchkin_assert_simple!((self.is_ready() || self.conflicting()) && !self.is_infeasible());
         self.internal_state = CSPSolverStateInternal::Solving;
     }
 

--- a/src/proof/processing/rp_engine.rs
+++ b/src/proof/processing/rp_engine.rs
@@ -212,6 +212,7 @@ impl RpEngine {
     fn backtrack_one_level(&mut self) {
         self.solver
             .backtrack(self.solver.get_decision_level() - 1, &mut DummyBrancher);
+        self.solver.state.declare_solving();
     }
 
     fn enqueue_and_propagate(


### PR DESCRIPTION
This ensures the RP engine solver doesn't remain in a conflicting state after using propagate_under_assumptions.